### PR TITLE
fix: make isDirty mean value-changed-from-initial

### DIFF
--- a/src/__tests__/basic/form-state.spec.ts
+++ b/src/__tests__/basic/form-state.spec.ts
@@ -28,7 +28,7 @@ describe('Form state and lifecycle', () => {
 		}
 	});
 
-	it('should report isDirty when all fields are modified', async () => {
+	it('should report isDirty when any single field is modified', async () => {
 		const cmp = defineComponent(() => {
 			const { Form, Field } = useForm({ name: 'fs-dirty' });
 
@@ -46,13 +46,70 @@ describe('Form state and lifecycle', () => {
 
 		expect(wrapper.find('.dirty').text()).toBe('false');
 
-		// Modify both fields (isDirty uses .every() so ALL fields must be dirty)
+		// Modifying a single field is enough to make the form dirty.
 		const inputs = wrapper.findAll('input');
 		await inputs[0].setValue('test@test.com');
-		await inputs[1].setValue('John');
 		await nextTick();
 
 		expect(wrapper.find('.dirty').text()).toBe('true');
+		wrapper.unmount();
+	});
+
+	it('should not be dirty on mount when fields have initial values', async () => {
+		const cmp = defineComponent(() => {
+			const { Form, Field } = useForm({
+				name: 'fs-dirty-initial',
+				initialValues: { email: 'test@test.com', name: 'John' },
+			});
+
+			return () => h(Form, {}, {
+				default: ({ isDirty }: any) => [
+					h(Field, { name: 'email' }),
+					h(Field, { name: 'name' }),
+					h('span', { class: 'dirty' }, `${isDirty}`),
+				],
+			});
+		});
+
+		const wrapper = mount(cmp);
+		await nextTick();
+		await nextTick();
+
+		// A field carrying an initial value is unchanged, so the form is pristine.
+		expect(wrapper.find('.dirty').text()).toBe('false');
+		wrapper.unmount();
+	});
+
+	it('should reset isDirty when a field returns to its initial value', async () => {
+		const cmp = defineComponent(() => {
+			const { Form, Field } = useForm({
+				name: 'fs-dirty-revert',
+				initialValues: { email: 'initial@test.com' },
+			});
+
+			return () => h(Form, {}, {
+				default: ({ isDirty }: any) => [
+					h(Field, { name: 'email' }),
+					h('span', { class: 'dirty' }, `${isDirty}`),
+				],
+			});
+		});
+
+		const wrapper = mount(cmp);
+		await nextTick();
+		await nextTick();
+
+		expect(wrapper.find('.dirty').text()).toBe('false');
+
+		const input = wrapper.find('input');
+		await input.setValue('changed@test.com');
+		await nextTick();
+		expect(wrapper.find('.dirty').text()).toBe('true');
+
+		// Typing the original value back clears the dirty state.
+		await input.setValue('initial@test.com');
+		await nextTick();
+		expect(wrapper.find('.dirty').text()).toBe('false');
 		wrapper.unmount();
 	});
 
@@ -232,12 +289,9 @@ describe('Form state and lifecycle', () => {
 
 		expect(wrapper.find('.dirty').text()).toBe('false');
 
-		// Input a value — first input sets isTouched, second sets isDirty
+		// A value differing from the initial value marks the field dirty.
 		const input = wrapper.find('input');
 		await input.setValue('a');
-		await input.trigger('input');
-		await nextTick();
-		await input.setValue('ab');
 		await input.trigger('input');
 		await nextTick();
 

--- a/src/components/Error.ts
+++ b/src/components/Error.ts
@@ -1,6 +1,6 @@
 import { forms } from '@/utils/store';
 import { GetKeys } from '@/utils/types';
-import { getErrorMessage, getValueByPath } from '@/utils/utils';
+import { getErrorMessage, getValueByPath, isFieldDirty } from '@/utils/utils';
 import { defineComponent, inject, h, SlotsType, PropType } from 'vue';
 
 export const ErrorComp = <T extends Record<string, any> = Record<string, any>>() => defineComponent(
@@ -8,7 +8,7 @@ export const ErrorComp = <T extends Record<string, any> = Record<string, any>>()
 		const { uid, mode, isSubmitted } = inject('formData', Object.create({}));
 		
 		const getError = () => {
-			if (mode === 'onSubmit' || isSubmitted.value || getValueByPath(forms[uid].values, props.errorFor as string)?.isDirty) {
+			if (mode === 'onSubmit' || isSubmitted.value || isFieldDirty(getValueByPath(forms[uid].values, props.errorFor as string))) {
 				return getErrorMessage(forms[uid].values, props.errorFor as string);
 			}
 		};

--- a/src/components/Form.ts
+++ b/src/components/Form.ts
@@ -1,6 +1,6 @@
 import { forms } from '@/utils/store';
 import { FormOptions, GetKeys, Prettify, RecursivePartial } from '@/utils/types';
-import { createFormDataFromObject, EventEmitter, fetcher, flattenObject, getValueByPath, mergeDeep, objectToString, stringToObject, hasDirty, hasErrors, getErrorMessage } from '@/utils/utils';
+import { createFormDataFromObject, EventEmitter, fetcher, flattenObject, getValueByPath, mergeDeep, objectToString, stringToObject, isFormDirty, hasErrors, getErrorMessage } from '@/utils/utils';
 import { validateSchema } from '@/utils/validator';
 import { computed, defineComponent, h, nextTick, onMounted, PropType, provide, ref, SlotsType, watch } from 'vue';
 
@@ -48,10 +48,9 @@ export const FormComponent = <T extends Record<string, any> = Record<string, any
 		if (getValueByPath(forms[uid].values, name as unknown as string)) {
 			const field = getValueByPath(forms[uid].values, name as unknown as string);
 			field.value = value;
-			field.isDirty = true;
 			field.error = undefined;
 		} else {
-			const obj = stringToObject(name as string, { value, error: undefined, isDirty: true });
+			const obj = stringToObject(name as string, { value, error: undefined });
 			forms[uid].values = mergeDeep(forms[uid].values, obj);
 		}
 		if (opt?.schema) {
@@ -65,7 +64,6 @@ export const FormComponent = <T extends Record<string, any> = Record<string, any
 			if (getValueByPath(forms[uid].values, key as string) && 'value' in getValueByPath(forms[uid].values, key as string)) {
 				const field = getValueByPath(forms[uid].values, key as string);
 				field.value = convertedKeys[key];
-				field.isDirty = true;
 				field.error = undefined;
 			}
 		}
@@ -92,7 +90,7 @@ export const FormComponent = <T extends Record<string, any> = Record<string, any
 		get: () => flattenObject(forms[uid]?.values) as T,
 		set: (newValue: T) => newValue,
 	});
-	const isDirty = computed(() => hasDirty(flattenObject(forms[uid]?.values, 'isDirty')));
+	const isDirty = computed(() => isFormDirty(forms[uid]?.values));
 	const isValid = computed(() => isDirty.value && !hasErrors(flattenObject(forms[uid]?.values, 'error')));
 	/*---------------------------------------------
 	/  CREATED

--- a/src/composable/useFieldValidation.ts
+++ b/src/composable/useFieldValidation.ts
@@ -1,4 +1,4 @@
-import { getValueByPath } from '@/utils/utils';
+import { getValueByPath, isFieldDirty } from '@/utils/utils';
 import { forms } from '@/utils/store';
 import { FieldDefaults } from '@/utils/types';
 import { validateSchema } from '@/utils/validator';
@@ -36,7 +36,7 @@ export const useFieldValidation = (
 	};
 
 	const getError = () =>
-		(fieldItem.value?.isDirty || isSubmitted.value || mode === 'onSubmit') ? fieldItem.value?.error : undefined;
+		(isFieldDirty(fieldItem.value) || isSubmitted.value || mode === 'onSubmit') ? fieldItem.value?.error : undefined;
 
 	return { setError, resetError, validateField, getError };
 }

--- a/src/composable/useInput.ts
+++ b/src/composable/useInput.ts
@@ -1,6 +1,6 @@
 import { computed, getCurrentInstance, inject, nextTick, onBeforeUnmount, onMounted, warn } from 'vue';
 import { forms } from '@/utils/store';
-import { createFormInput, deleteByPath, EventEmitter, getValueByPath, mergeDeep, objectToModelValue } from '@/utils/utils';
+import { cloneValue, createFormInput, deleteByPath, EventEmitter, getValueByPath, isFieldDirty, mergeDeep, objectToModelValue } from '@/utils/utils';
 import { FieldArrayType, FieldDefaults, FieldType, InputProps, UseInputOption } from '@/utils/types';
 import { useFieldValidation } from './useFieldValidation';
 
@@ -45,17 +45,17 @@ export const useInput = <T extends Record<string, any> = InputProps>(
 	/* FIELD STATE */
 	const defaultValue: FieldDefaults = {
 		value: getValueByPath(forms[uid].values, name)?.value ?? undefined,
+		initialValue: undefined,
 		error: undefined,
 		ignore: props.ignore,
-		isDirty: false,
 		isTouched: false,
 		isValid: true,
 	};
 
 	const fieldItem = computed<FieldDefaults>(() => getValueByPath(forms[uid].values, name));
-	const isValid = computed(() => !(fieldItem.value?.error && (fieldItem.value.isDirty || isSubmitted.value || mode === 'onSubmit')));
+	const isDirty = computed(() => isFieldDirty(fieldItem.value));
 	const isTouched = computed(() => fieldItem.value?.isTouched);
-	const isDirty = computed(() => fieldItem.value?.isDirty);
+	const isValid = computed(() => !(fieldItem.value?.error && (isDirty.value || isSubmitted.value || mode === 'onSubmit')));
 
 	const setArrayValue = (value: any, key: any = name) => {
 		const field = getValueByPath(forms[uid].values, key);
@@ -77,9 +77,6 @@ export const useInput = <T extends Record<string, any> = InputProps>(
 		set(newVal) {
 			if (!fieldItem.value) {
 				return;
-			}
-			if (fieldItem.value?.isTouched && defaultValue.value !== value.value) {
-				fieldItem.value.isDirty = true;
 			}
 			if (opt.isArray || Array.isArray(newVal)) {
 				fieldItem.value.value = [];
@@ -172,7 +169,9 @@ export const useInput = <T extends Record<string, any> = InputProps>(
 	if (!name) {
 		warn('`name` prop is required');
 	} else {
-		fieldItem.value.value = getInitialValue();
+		const initial = getInitialValue();
+		fieldItem.value.value = initial;
+		fieldItem.value.initialValue = cloneValue(initial);
 	}
 
 	/* LIFECYCLE */
@@ -185,7 +184,6 @@ export const useInput = <T extends Record<string, any> = InputProps>(
 
 	onMounted(async () => {
 		await nextTick();
-		(value.value && !Array.isArray(value.value) && fieldItem.value) && (fieldItem.value.isDirty = true);
 		if (vm?.subTree?.el) {
 			if ('as' in props && props.as === 'select') {
 				const options = Array.from((vm.subTree.el as unknown as HTMLSelectElement).options);

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -124,9 +124,9 @@ export type InputProps<T extends Record<string, any> = Record<string, any>> = {
 
 export type FieldDefaults = {
 	value: any,
+	initialValue: any,
 	error: any,
 	ignore: boolean | undefined,
-	isDirty: boolean,
 	isTouched: boolean,
 	isValid: boolean,
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -188,21 +188,113 @@ export const deleteByPath = (object: Record<string, any>, path: string) => {
 	}
 };
 
-export function hasDirty(dirty: any): boolean {
-	if (typeof dirty === 'boolean') {
-		return dirty;
+/**
+ * Deep clone a value. Primitives are returned as-is; objects/arrays are
+ * structurally cloned so a stored snapshot can't be mutated by later writes.
+ */
+export const cloneValue = (val: any): any => {
+	if (val === null || typeof val !== 'object') {
+		return val;
 	}
 
-	if (Array.isArray(dirty)) {
-		return dirty.every(item => hasDirty(item));
+	try {
+		return JSON.parse(JSON.stringify(val));
+	} catch {
+		return val;
+	}
+};
+
+/**
+ * Structural equality. Treats `undefined`-valued keys and missing keys as
+ * equivalent so a JSON-cloned snapshot (which drops `undefined`) still matches
+ * a live field object that carries `error: undefined`.
+ */
+export const isEqual = (a: any, b: any): boolean => {
+	if (a === b) {
+		return true;
 	}
 
-	if (typeof dirty === 'object' && dirty !== null) {
-		return Object.values(dirty).every(value => hasDirty(value));
+	if (typeof a !== typeof b) {
+		return false;
+	}
+
+	if (typeof a !== 'object' || a === null || b === null) {
+		// NaN === NaN
+		return a !== a && b !== b;
+	}
+
+	if (a instanceof Date || b instanceof Date) {
+		return a instanceof Date && b instanceof Date && a.getTime() === b.getTime();
+	}
+
+	if (typeof File !== 'undefined' && (a instanceof File || b instanceof File)) {
+		return a === b;
+	}
+
+	if (typeof Blob !== 'undefined' && (a instanceof Blob || b instanceof Blob)) {
+		return a === b;
+	}
+
+	const aIsArray = Array.isArray(a);
+	const bIsArray = Array.isArray(b);
+	if (aIsArray !== bIsArray) {
+		return false;
+	}
+
+	if (aIsArray) {
+		if (a.length !== b.length) {
+			return false;
+		}
+
+		return a.every((item: any, index: number) => isEqual(item, b[index]));
+	}
+
+	const aKeys = Object.keys(a).filter(key => a[key] !== undefined);
+	const bKeys = Object.keys(b).filter(key => b[key] !== undefined);
+	if (aKeys.length !== bKeys.length) {
+		return false;
+	}
+
+	return aKeys.every(key => isEqual(a[key], b[key]));
+};
+
+/**
+ * A single field is dirty when its current value differs from the value it was
+ * initialised with.
+ */
+export const isFieldDirty = (field: any): boolean =>
+	!!field && typeof field === 'object' && 'value' in field && !isEqual(field.value, field.initialValue);
+
+/**
+ * The form is dirty when any field in it is dirty. Walks the nested store,
+ * treating nodes that carry a `value` key as leaf fields (covers scalar,
+ * object-value and array fields) and recursing through dot-path segments.
+ */
+export const isFormDirty = (values: Record<string, any>): boolean => {
+	if (!values || typeof values !== 'object') {
+		return false;
+	}
+
+	for (const key in values) {
+		const node = values[key];
+		if (!node || typeof node !== 'object') {
+			continue;
+		}
+
+		if ('value' in node) {
+			if (node.ignore) {
+				continue;
+			}
+			if (isFieldDirty(node)) {
+				return true;
+			}
+		} else if (isFormDirty(node)) {
+			return true;
+		}
 	}
 
 	return false;
-}
+};
 
 export function hasErrors(errors: any): boolean {
 	if (typeof errors === 'string' && errors) {
@@ -224,7 +316,7 @@ export const getErrorMessage = <T extends Record<string, any>>(values: Record<st
 	return getValueByPath(values, errorFor as string)?.error;
 };
 
-export const flattenObject = (obj: any, type: 'value' | 'error' | 'isDirty' = 'value'): Record<string, any> => {
+export const flattenObject = (obj: any, type: 'value' | 'error' = 'value'): Record<string, any> => {
 	const result: any = {};
 	for (const key in obj) {
 		if (obj[key] && typeof obj[key] === 'object' && 'value' in obj[key]) {


### PR DESCRIPTION
Field state polish — fix isDirty semantics so it means "current value differs from the field's initial value" instead of a sticky, partly-broken flag.

- Store a per-field `initialValue` captured at field init; derive `isDirty` from `!isEqual(value, initialValue)` (single source of truth).
- Form-level `isDirty` now true when ANY field is dirty (was `.every()`, so it only reported dirty once every field changed).
- A field with an initial value is no longer marked dirty on mount.
- Dirty now clears when a value is edited back to its initial value (previously sticky once set).
- Drop manual `isDirty = true` writes in the value setter and in Form.setValue/setValues; remove the now-unused `hasDirty` helper and the `'isDirty'` flatten mode.

Add `isEqual` (undefined-tolerant deep equal), `cloneValue`, `isFieldDirty`, and `isFormDirty` helpers. Update form-state tests to the new semantics and add regression coverage (single-field dirty, no dirty on mount with initial values, dirty resets on revert).