### PR TITLE
Feature/valid state decouple

### DIFF
--- a/playground/App.vue
+++ b/playground/App.vue
@@ -1,97 +1,320 @@
-<!-- eslint-disable @typescript-eslint/no-unused-vars -->
 <script lang="ts" setup>
 import { type } from 'arktype';
-import { ref } from 'vue';
 import { useForm } from '@/main';
-import ObjectInput from './ObjectInput.vue';
-import InputNumber from 'primevue/inputnumber';
-import InputOtp from 'primevue/inputotp';
 
 /*---------------------------------------------
-/  PROPS & EMITS
+/  SCHEMA
+/  Validation runs live because mode is 'onChange'.
 ---------------------------------------------*/
-const UserForm = type({
-	firstName: type.string.atLeastLength(2).configure({ message: 'First name is required' }),
-	list: type.string.array().configure({ message: 'List is required' }),
-	accept: type.boolean.configure({ message: 'Accept is required' }),
-	customCheckbox: type.string.configure({ message: 'Accept is required' }),
-	number: type.number.configure({ message: 'Number is required' }),
-	otp: type.number.configure({ message: 'Number is required' }),
+const schema = type({
+	username: type.string.atLeastLength(3).configure({ message: 'Username must be at least 3 characters' }),
+	email: type.string.atLeastLength(5).configure({ message: 'Email must be at least 5 characters' }),
 });
 
-const stringType = type.string.atLeastLength(2).configure({ message: 'Last name is required' });
 /*---------------------------------------------
-/  VARIABLES
+/  FORM
+/  Starts with VALID initial values, so on mount the form is
+/  pristine (not dirty) AND valid — that combination is the whole
+/  point of Batch 2.
 ---------------------------------------------*/
-const OtherForm = useForm({ name: 'other' });
-const { Form, Field, Error, FieldArray } = useForm({
-	name: 'UserForm',
+const { Form, Field, Error, reset, setError } = useForm({
+	name: 'state-demo',
 	mode: 'onChange',
 	initialValues: {
-		list: ['asd', 'lol', '123'],
-		accept: false,
-		customCheckbox: 'foo',
+		username: 'alice',
+		email: 'alice@example.com',
 	},
-	schema: UserForm,
+	schema,
 });
-const cities = ref([
-	{ name: 'New York', code: 'NY' },
-	{ name: 'Rome', code: 'RM' },
-	{ name: 'London', code: 'LDN' },
-	{ name: 'Istanbul', code: 'IST' },
-	{ name: 'Paris', code: 'PRS' },
-]);
-/*---------------------------------------------
-/  METHODS
----------------------------------------------*/
-/*---------------------------------------------
-/  COMPUTED
----------------------------------------------*/
-/*---------------------------------------------
-/  WATCHERS
----------------------------------------------*/
-/*---------------------------------------------
-/  CREATED
----------------------------------------------*/
-/*---------------------------------------------
-/  HOOKS
----------------------------------------------*/
-const test = ref<number>(0);
+
+// Batch 2 demo: set an error WITHOUT touching the field. Validity flips to
+// false immediately, but the message stays hidden until the field is dirty
+// or the form is submitted (error display is gated, validity is not).
+const flagEmail = () => setError('email', 'Flagged invalid programmatically');
 </script>
+
 <template>
-	<div class="container">
-		<OtherForm.Form v-slot="{ values: otherValues }">
-			<pre>{{ otherValues }}</pre>
-			<OtherForm.Field name="booo"></OtherForm.Field>
-		</OtherForm.Form>
-		<Form v-slot="{ values, isValid }">
-			{{ test }}
-			<InputNumber v-model="test" />
-			<pre>{{ values }}</pre>
-			<Field name="number" v-slot="{ field }">
-				<InputNumber v-bind="field" :default-value="0" />
-			</Field>
-			<Field name="otp" v-slot="{ field }">
-				<!-- <InputNumber v-bind="field" inputId="expiry" prefix="Expires in " suffix=" days" fluid /> -->
-				<InputOtp v-bind="field" />
-			</Field>
-			<ObjectInput name="asd" :default="{ min: 30, max: 100 }" />
-			<Field name="firstName" :rule="stringType" />
-			<Error error-for="firstName" />
-			<Field name="accept" type="checkbox" />
-			<Error error-for="accept" />
-			<Field name="customCheckbox" type="checkbox" true-value="foo" false-value="bar" :rule="type.boolean" />
-			<FieldArray name="list" v-slot="{ add, fields, remove }">
-				<button @click="add">
-					Add
-				</button>
-				<div :key="index" v-for="(field, index) in fields">
-					<Field :key="index" :name="`list[${index}]`" :rule="stringType" />
-					<button @click="remove(field.id)">
-						Remove
-					</button>
+	<div class="page">
+		<header>
+			<h1>vue-formify — field state demo</h1>
+			<p class="sub">
+				Live demonstration of <strong>Batch 1 (isDirty)</strong> and
+				<strong>Batch 2 (isValid)</strong>. The form starts with valid initial
+				values, so it mounts <em>pristine and valid</em>.
+			</p>
+		</header>
+
+		<div class="cards">
+			<div class="card">
+				<h2>Batch 1 — <code>isDirty</code></h2>
+				<ul>
+					<li>A field with an initial value is <b>not</b> dirty on mount.</li>
+					<li>The form is dirty when <b>any single</b> field changes.</li>
+					<li>Editing a value back to its initial clears dirty (not sticky).</li>
+				</ul>
+			</div>
+			<div class="card">
+				<h2>Batch 2 — <code>isValid</code></h2>
+				<ul>
+					<li>A pristine form with no errors is <b>valid</b> (independent of dirty).</li>
+					<li>Validity is derived purely from error state.</li>
+					<li>A field error makes the form invalid — even while pristine.</li>
+				</ul>
+			</div>
+		</div>
+
+		<Form v-slot="{ values, isDirty, isValid }">
+			<!-- FORM-LEVEL STATE -->
+			<div class="statusbar">
+				<span class="badge" :class="isDirty ? 'on' : 'off'">
+					form.isDirty: {{ isDirty }}
+				</span>
+				<span class="badge" :class="isValid ? 'valid' : 'invalid'">
+					form.isValid: {{ isValid }}
+				</span>
+			</div>
+
+			<!-- USERNAME -->
+			<Field name="username" v-slot="{ field }">
+				<div class="row">
+					<label>Username</label>
+					<input
+						:value="field.value"
+						@input="field.onInput"
+						@focus="field.onFocus"
+						@blur="field.onBlur"
+					>
+					<div class="field-state">
+						<span class="badge sm" :class="field.isDirty ? 'on' : 'off'">dirty: {{ field.isDirty }}</span>
+						<span class="badge sm" :class="field.isTouched ? 'on' : 'off'">touched: {{ field.isTouched }}</span>
+						<span class="badge sm" :class="field.isValid ? 'valid' : 'invalid'">valid: {{ field.isValid }}</span>
+					</div>
+					<Error error-for="username" class="error" />
 				</div>
-			</FieldArray>
-		</form>
+			</Field>
+
+			<!-- EMAIL -->
+			<Field name="email" v-slot="{ field }">
+				<div class="row">
+					<label>Email</label>
+					<input
+						:value="field.value"
+						@input="field.onInput"
+						@focus="field.onFocus"
+						@blur="field.onBlur"
+					>
+					<div class="field-state">
+						<span class="badge sm" :class="field.isDirty ? 'on' : 'off'">dirty: {{ field.isDirty }}</span>
+						<span class="badge sm" :class="field.isTouched ? 'on' : 'off'">touched: {{ field.isTouched }}</span>
+						<span class="badge sm" :class="field.isValid ? 'valid' : 'invalid'">valid: {{ field.isValid }}</span>
+					</div>
+					<Error error-for="email" class="error" />
+				</div>
+			</Field>
+
+			<div class="actions">
+				<button type="submit">Submit</button>
+				<button type="button" @click="reset()">Reset</button>
+				<button type="button" @click="flagEmail">
+					Flag email invalid (programmatic)
+				</button>
+			</div>
+
+			<p class="hint">
+				Try: type 2 chars in Username → <code>form.isDirty</code> becomes
+				<code>true</code> and that field's <code>isValid</code> becomes
+				<code>false</code>. Type the original value back → dirty returns to
+				<code>false</code>. Click <em>Flag email invalid</em> while you haven't
+				touched the email → <code>isValid</code> flips to <code>false</code> but
+				the message only appears after you focus the field or submit.
+			</p>
+
+			<pre>{{ values }}</pre>
+		</Form>
 	</div>
 </template>
+
+<style scoped>
+.page {
+	max-width: 720px;
+	margin: 0 auto;
+	padding: 2rem 1.25rem 4rem;
+	font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+	color: #1f2933;
+}
+
+h1 {
+	font-size: 1.5rem;
+	margin: 0 0 0.25rem;
+}
+
+.sub {
+	margin: 0 0 1.5rem;
+	color: #52606d;
+	font-size: 0.9rem;
+}
+
+.cards {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 1rem;
+	margin-bottom: 2rem;
+}
+
+.card {
+	border: 1px solid #e4e7eb;
+	border-radius: 10px;
+	padding: 1rem 1.25rem;
+	background: #f9fafb;
+}
+
+.card h2 {
+	font-size: 1rem;
+	margin: 0 0 0.5rem;
+}
+
+.card ul {
+	margin: 0;
+	padding-left: 1.1rem;
+	font-size: 0.85rem;
+	color: #3e4c59;
+	line-height: 1.5;
+}
+
+code {
+	background: #eef2f7;
+	padding: 0.1em 0.35em;
+	border-radius: 4px;
+	font-size: 0.85em;
+}
+
+.statusbar {
+	display: flex;
+	gap: 0.5rem;
+	margin-bottom: 1.5rem;
+	position: sticky;
+	top: 0;
+	background: #fff;
+	padding: 0.5rem 0;
+	z-index: 1;
+}
+
+.row {
+	margin-bottom: 1.5rem;
+	display: flex;
+	flex-direction: column;
+	gap: 0.4rem;
+}
+
+label {
+	font-weight: 600;
+	font-size: 0.85rem;
+}
+
+input {
+	padding: 0.55rem 0.7rem;
+	border: 1px solid #cbd2d9;
+	border-radius: 8px;
+	font-size: 0.95rem;
+	max-width: 320px;
+}
+
+input:focus {
+	outline: 2px solid #3b82f6;
+	outline-offset: 0;
+	border-color: transparent;
+}
+
+.field-state {
+	display: flex;
+	gap: 0.4rem;
+	flex-wrap: wrap;
+}
+
+.badge {
+	font-size: 0.78rem;
+	font-weight: 600;
+	padding: 0.2rem 0.55rem;
+	border-radius: 999px;
+	border: 1px solid transparent;
+}
+
+.badge.sm {
+	font-size: 0.72rem;
+}
+
+.badge.on {
+	background: #fff7ed;
+	color: #c2410c;
+	border-color: #fed7aa;
+}
+
+.badge.off {
+	background: #f1f5f9;
+	color: #64748b;
+	border-color: #e2e8f0;
+}
+
+.badge.valid {
+	background: #ecfdf5;
+	color: #047857;
+	border-color: #a7f3d0;
+}
+
+.badge.invalid {
+	background: #fef2f2;
+	color: #b91c1c;
+	border-color: #fecaca;
+}
+
+.error {
+	color: #b91c1c;
+	font-size: 0.8rem;
+	min-height: 1rem;
+}
+
+.actions {
+	display: flex;
+	gap: 0.5rem;
+	flex-wrap: wrap;
+	margin: 1.5rem 0;
+}
+
+button {
+	padding: 0.5rem 0.9rem;
+	border: 1px solid #cbd2d9;
+	border-radius: 8px;
+	background: #fff;
+	font-size: 0.85rem;
+	cursor: pointer;
+}
+
+button[type='submit'] {
+	background: #3b82f6;
+	border-color: #3b82f6;
+	color: #fff;
+}
+
+button:hover {
+	filter: brightness(0.97);
+}
+
+.hint {
+	font-size: 0.82rem;
+	color: #52606d;
+	line-height: 1.6;
+	background: #f9fafb;
+	border-left: 3px solid #3b82f6;
+	padding: 0.75rem 1rem;
+	border-radius: 0 8px 8px 0;
+}
+
+pre {
+	background: #0f172a;
+	color: #e2e8f0;
+	padding: 1rem;
+	border-radius: 8px;
+	font-size: 0.8rem;
+	overflow-x: auto;
+}
+</style>

--- a/src/__tests__/basic/form-state.spec.ts
+++ b/src/__tests__/basic/form-state.spec.ts
@@ -113,14 +113,15 @@ describe('Form state and lifecycle', () => {
 		wrapper.unmount();
 	});
 
-	it('should report isValid when form is dirty with no errors', async () => {
+	it('should report isValid for a pristine form with no errors (independent of dirty)', async () => {
 		const cmp = defineComponent(() => {
 			const { Form, Field } = useForm({ name: 'fs-valid' });
 
 			return () => h(Form, {}, {
-				default: ({ isValid }: any) => [
+				default: ({ isValid, isDirty }: any) => [
 					h(Field, { name: 'email' }),
 					h('span', { class: 'valid' }, `${isValid}`),
+					h('span', { class: 'dirty' }, `${isDirty}`),
 				],
 			});
 		});
@@ -128,15 +129,47 @@ describe('Form state and lifecycle', () => {
 		const wrapper = mount(cmp);
 		await nextTick();
 
-		// Not dirty yet, so isValid is false
-		expect(wrapper.find('.valid').text()).toBe('false');
+		// Pristine and error-free: valid is true even though dirty is false.
+		expect(wrapper.find('.dirty').text()).toBe('false');
+		expect(wrapper.find('.valid').text()).toBe('true');
 
-		// Make the field dirty by entering a value
+		// Entering a value makes it dirty but it stays valid (no errors).
 		await wrapper.find('input').setValue('test@test.com');
 		await nextTick();
 
-		// Now dirty with no errors, so isValid is true
+		expect(wrapper.find('.dirty').text()).toBe('true');
 		expect(wrapper.find('.valid').text()).toBe('true');
+		wrapper.unmount();
+	});
+
+	it('should report invalid when a field has an error, regardless of dirty state', async () => {
+		const cmp = defineComponent(() => {
+			const { Form, Field, setError } = useForm({ name: 'fs-valid-error' });
+
+			return () => h(Form, {}, {
+				default: ({ isValid, isDirty }: any) => [
+					h(Field, { name: 'email' }),
+					h('button', {
+						type: 'button',
+						onClick: () => setError('email', 'Invalid email'),
+					}, 'Set Error'),
+					h('span', { class: 'valid' }, `${isValid}`),
+					h('span', { class: 'dirty' }, `${isDirty}`),
+				],
+			});
+		});
+
+		const wrapper = mount(cmp);
+		await nextTick();
+
+		expect(wrapper.find('.valid').text()).toBe('true');
+
+		// An error makes the form invalid even though it is still pristine.
+		await wrapper.find('button').trigger('click');
+		await nextTick();
+
+		expect(wrapper.find('.dirty').text()).toBe('false');
+		expect(wrapper.find('.valid').text()).toBe('false');
 		wrapper.unmount();
 	});
 
@@ -299,7 +332,7 @@ describe('Form state and lifecycle', () => {
 		wrapper.unmount();
 	});
 
-	it('should recalculate isValid after setValue', async () => {
+	it('should stay valid after setValue when no schema introduces errors', async () => {
 		const cmp = defineComponent(() => {
 			const { Form, Field, setValue } = useForm({ name: 'fs-setvalue-valid' });
 
@@ -318,7 +351,8 @@ describe('Form state and lifecycle', () => {
 		const wrapper = mount(cmp);
 		await nextTick();
 
-		expect(wrapper.find('.valid').text()).toBe('false');
+		// Valid from the start (no errors), and a programmatic setValue keeps it so.
+		expect(wrapper.find('.valid').text()).toBe('true');
 
 		await wrapper.find('button').trigger('click');
 		await nextTick();
@@ -327,7 +361,7 @@ describe('Form state and lifecycle', () => {
 		wrapper.unmount();
 	});
 
-	it('should recalculate isValid after setValues', async () => {
+	it('should stay valid after setValues when no schema introduces errors', async () => {
 		const cmp = defineComponent(() => {
 			const { Form, Field, setValues } = useForm({ name: 'fs-setvalues-valid' });
 
@@ -347,7 +381,7 @@ describe('Form state and lifecycle', () => {
 		const wrapper = mount(cmp);
 		await nextTick();
 
-		expect(wrapper.find('.valid').text()).toBe('false');
+		expect(wrapper.find('.valid').text()).toBe('true');
 
 		await wrapper.find('button').trigger('click');
 		await nextTick();
@@ -408,7 +442,8 @@ describe('Form state and lifecycle', () => {
 		const wrapper = mount(cmp);
 		await nextTick();
 
-		expect(wrapper.find('.valid').text()).toBe('false');
+		// Pristine with no validation run yet → valid.
+		expect(wrapper.find('.valid').text()).toBe('true');
 
 		await wrapper.find('button').trigger('click');
 		await nextTick();

--- a/src/components/Field.ts
+++ b/src/components/Field.ts
@@ -9,7 +9,20 @@ export const FieldComp = <T extends Record<string, any> = Record<string, any>>()
 	any,
 	string,
 	SlotsType<{
-		default: { field: { value: any, modelValue: any, isValid: boolean, error: any } }
+		default: {
+			field: {
+				value: any,
+				modelValue: any,
+				'onUpdate:modelValue': (val: any) => void,
+				onInput: (evt: any) => void,
+				onFocus: () => void,
+				onBlur: () => void,
+				error: any,
+				isValid: boolean,
+				isDirty: boolean,
+				isTouched: boolean,
+			}
+		}
 	}>
 >(
 	(props: FieldType<T>, { slots, attrs: baseAttrs }) => {

--- a/src/components/Form.ts
+++ b/src/components/Form.ts
@@ -80,7 +80,6 @@ export const FormComponent = <T extends Record<string, any> = Record<string, any
 	const setError = (name: GetKeys<T>, error: any) => {
 		if (getValueByPath(forms[uid].values, name as unknown as string)) {
 			getValueByPath(forms[uid].values, name as unknown as string).error = error;
-			getValueByPath(forms[uid].values, name as unknown as string).isValid = false;
 		}
 	};
 	/*---------------------------------------------
@@ -91,7 +90,8 @@ export const FormComponent = <T extends Record<string, any> = Record<string, any
 		set: (newValue: T) => newValue,
 	});
 	const isDirty = computed(() => isFormDirty(forms[uid]?.values));
-	const isValid = computed(() => isDirty.value && !hasErrors(flattenObject(forms[uid]?.values, 'error')));
+	// Validity is independent of dirtiness: a pristine form with no errors is valid.
+	const isValid = computed(() => !hasErrors(flattenObject(forms[uid]?.values, 'error')));
 	/*---------------------------------------------
 	/  CREATED
 	---------------------------------------------*/

--- a/src/composable/useFieldValidation.ts
+++ b/src/composable/useFieldValidation.ts
@@ -28,10 +28,7 @@ export const useFieldValidation = (
 
 	const validateField = async () => {
 		if (rule) {
-			const result = await validateSchema(rule, value.value, setError, name);
-			if (fieldItem.value) {
-				fieldItem.value.isValid = result;
-			}
+			return await validateSchema(rule, value.value, setError, name);
 		}
 	};
 

--- a/src/composable/useInput.ts
+++ b/src/composable/useInput.ts
@@ -49,13 +49,14 @@ export const useInput = <T extends Record<string, any> = InputProps>(
 		error: undefined,
 		ignore: props.ignore,
 		isTouched: false,
-		isValid: true,
 	};
 
 	const fieldItem = computed<FieldDefaults>(() => getValueByPath(forms[uid].values, name));
 	const isDirty = computed(() => isFieldDirty(fieldItem.value));
 	const isTouched = computed(() => fieldItem.value?.isTouched);
-	const isValid = computed(() => !(fieldItem.value?.error && (isDirty.value || isSubmitted.value || mode === 'onSubmit')));
+	// Validity is derived purely from the field's error state, independent of
+	// dirty/touched. Whether the error is *shown* is gated separately (getError).
+	const isValid = computed(() => !fieldItem.value?.error);
 
 	const setArrayValue = (value: any, key: any = name) => {
 		const field = getValueByPath(forms[uid].values, key);

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -128,7 +128,6 @@ export type FieldDefaults = {
 	error: any,
 	ignore: boolean | undefined,
 	isTouched: boolean,
-	isValid: boolean,
 }
 
 export type RecursivePartial<T> = {


### PR DESCRIPTION
Makes error state the single source of truth for validity and decouples `isValid` from `isDirty`.

  - Field `isValid → !error` (pure validity, independent of dirty/touched).
  - Form `isValid → !hasErrors(...)` — a pristine form with no errors is now valid (was `isDirty && !hasErrors`, which falsely reported a clean form as invalid).
  - Removed the dead stored isValid flag (written in 3 places, read nowhere).
  - Validity and error display are now separate concerns: display stays gated by dirty/submitted via `getError / Error`.

  Also: completed the `Field` slot type (now types `isDirty, isTouched, onInput, onFocus, onBlur, onUpdate:modelValue`— already exposed at runtime)

⚠️  **Behavior change**: isValid now reflects error state immediately (a pristine form is valid; a programmatic error makes it invalid while still pristine). Effectivelysemver-major for isValid.