### PR TITLE
Feature/expose form state

### DIFF
--- a/playground/App.vue
+++ b/playground/App.vue
@@ -16,8 +16,25 @@ const schema = type({
 /  Starts with VALID initial values, so on mount the form is
 /  pristine (not dirty) AND valid — that combination is the whole
 /  point of Batch 2.
+/
+/  Batch 3: the form-level state (isDirty/isValid/isTouched/
+/  isSubmitted/submitCount) and getFieldState come straight off the
+/  useForm() return — no <Form> slot needed.
 ---------------------------------------------*/
-const { Form, Field, Error, reset, setError } = useForm({
+const {
+	Form,
+	Field,
+	Error,
+	reset,
+	setError,
+	getFieldState,
+	isDirty,
+	isValid,
+	isTouched,
+	isSubmitted,
+	submitCount,
+	values,
+} = useForm({
 	name: 'state-demo',
 	mode: 'onChange',
 	initialValues: {
@@ -31,6 +48,10 @@ const { Form, Field, Error, reset, setError } = useForm({
 // false immediately, but the message stays hidden until the field is dirty
 // or the form is submitted (error display is gated, validity is not).
 const flagEmail = () => setError('email', 'Flagged invalid programmatically');
+
+const onSubmit = (val: unknown) => {
+	console.log('submitted', val);
+};
 </script>
 
 <template>
@@ -38,9 +59,10 @@ const flagEmail = () => setError('email', 'Flagged invalid programmatically');
 		<header>
 			<h1>vue-formify — field state demo</h1>
 			<p class="sub">
-				Live demonstration of <strong>Batch 1 (isDirty)</strong> and
-				<strong>Batch 2 (isValid)</strong>. The form starts with valid initial
-				values, so it mounts <em>pristine and valid</em>.
+				Live demonstration of <strong>Batch 1 (isDirty)</strong>,
+				<strong>Batch 2 (isValid)</strong> and
+				<strong>Batch 3 (complete state surface)</strong>. The form starts with
+				valid initial values, so it mounts <em>pristine and valid</em>.
 			</p>
 		</header>
 
@@ -61,19 +83,26 @@ const flagEmail = () => setError('email', 'Flagged invalid programmatically');
 					<li>A field error makes the form invalid — even while pristine.</li>
 				</ul>
 			</div>
+			<div class="card">
+				<h2>Batch 3 — state surface</h2>
+				<ul>
+					<li><code>isDirty/isValid/isTouched/isSubmitted/submitCount</code> on the <code>useForm()</code> return.</li>
+					<li><code>getFieldState(name)</code> reads a single field, no slot needed.</li>
+					<li>Same set is also available on the <code>&lt;Form&gt;</code> slot.</li>
+				</ul>
+			</div>
 		</div>
 
-		<Form v-slot="{ values, isDirty, isValid }">
-			<!-- FORM-LEVEL STATE -->
-			<div class="statusbar">
-				<span class="badge" :class="isDirty ? 'on' : 'off'">
-					form.isDirty: {{ isDirty }}
-				</span>
-				<span class="badge" :class="isValid ? 'valid' : 'invalid'">
-					form.isValid: {{ isValid }}
-				</span>
-			</div>
+		<!-- FORM-LEVEL STATE — straight from the useForm() return (Batch 3) -->
+		<div class="statusbar">
+			<span class="badge" :class="isDirty ? 'on' : 'off'">isDirty: {{ isDirty }}</span>
+			<span class="badge" :class="isValid ? 'valid' : 'invalid'">isValid: {{ isValid }}</span>
+			<span class="badge" :class="isTouched ? 'on' : 'off'">isTouched: {{ isTouched }}</span>
+			<span class="badge" :class="isSubmitted ? 'on' : 'off'">isSubmitted: {{ isSubmitted }}</span>
+			<span class="badge count">submitCount: {{ submitCount }}</span>
+		</div>
 
+		<Form @submit="onSubmit">
 			<!-- USERNAME -->
 			<Field name="username" v-slot="{ field }">
 				<div class="row">
@@ -119,24 +148,42 @@ const flagEmail = () => setError('email', 'Flagged invalid programmatically');
 					Flag email invalid (programmatic)
 				</button>
 			</div>
-
-			<p class="hint">
-				Try: type 2 chars in Username → <code>form.isDirty</code> becomes
-				<code>true</code> and that field's <code>isValid</code> becomes
-				<code>false</code>. Type the original value back → dirty returns to
-				<code>false</code>. Click <em>Flag email invalid</em> while you haven't
-				touched the email → <code>isValid</code> flips to <code>false</code> but
-				the message only appears after you focus the field or submit.
-			</p>
-
-			<pre>{{ values }}</pre>
 		</Form>
+
+		<!-- getFieldState INSPECTOR (Batch 3) -->
+		<section class="inspector">
+			<h3>getFieldState(name) — live snapshot</h3>
+			<div class="inspector-grid">
+				<div>
+					<h4>username</h4>
+					<pre>{{ getFieldState('username') }}</pre>
+				</div>
+				<div>
+					<h4>email</h4>
+					<pre>{{ getFieldState('email') }}</pre>
+				</div>
+			</div>
+		</section>
+
+		<p class="hint">
+			Try: type 2 chars in Username → <code>isDirty</code> becomes
+			<code>true</code> and that field's <code>isValid</code> becomes
+			<code>false</code>. Type the original value back → dirty returns to
+			<code>false</code>. Focus then blur a field → <code>isTouched</code>
+			flips. Click <em>Flag email invalid</em> while you haven't touched the
+			email → <code>isValid</code> flips to <code>false</code> but the message
+			only appears after you focus the field or submit. Hit <em>Submit</em>
+			a few times → <code>isSubmitted</code> and <code>submitCount</code>
+			update; <em>Reset</em> clears them.
+		</p>
+
+		<pre class="values">{{ values }}</pre>
 	</div>
 </template>
 
 <style scoped>
 .page {
-	max-width: 720px;
+	max-width: 760px;
 	margin: 0 auto;
 	padding: 2rem 1.25rem 4rem;
 	font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
@@ -156,7 +203,7 @@ h1 {
 
 .cards {
 	display: grid;
-	grid-template-columns: 1fr 1fr;
+	grid-template-columns: repeat(3, 1fr);
 	gap: 1rem;
 	margin-bottom: 2rem;
 }
@@ -169,14 +216,14 @@ h1 {
 }
 
 .card h2 {
-	font-size: 1rem;
+	font-size: 0.95rem;
 	margin: 0 0 0.5rem;
 }
 
 .card ul {
 	margin: 0;
 	padding-left: 1.1rem;
-	font-size: 0.85rem;
+	font-size: 0.82rem;
 	color: #3e4c59;
 	line-height: 1.5;
 }
@@ -191,6 +238,7 @@ code {
 .statusbar {
 	display: flex;
 	gap: 0.5rem;
+	flex-wrap: wrap;
 	margin-bottom: 1.5rem;
 	position: sticky;
 	top: 0;
@@ -267,6 +315,12 @@ input:focus {
 	border-color: #fecaca;
 }
 
+.badge.count {
+	background: #eef2ff;
+	color: #4338ca;
+	border-color: #c7d2fe;
+}
+
 .error {
 	color: #b91c1c;
 	font-size: 0.8rem;
@@ -299,6 +353,28 @@ button:hover {
 	filter: brightness(0.97);
 }
 
+.inspector {
+	margin: 2rem 0 1rem;
+}
+
+.inspector h3 {
+	font-size: 0.95rem;
+	margin: 0 0 0.75rem;
+}
+
+.inspector h4 {
+	font-size: 0.8rem;
+	margin: 0 0 0.35rem;
+	color: #52606d;
+	font-family: ui-monospace, monospace;
+}
+
+.inspector-grid {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 1rem;
+}
+
 .hint {
 	font-size: 0.82rem;
 	color: #52606d;
@@ -316,5 +392,10 @@ pre {
 	border-radius: 8px;
 	font-size: 0.8rem;
 	overflow-x: auto;
+	margin: 0;
+}
+
+pre.values {
+	margin-top: 1.5rem;
 }
 </style>

--- a/src/__tests__/basic/form-state.spec.ts
+++ b/src/__tests__/basic/form-state.spec.ts
@@ -486,4 +486,117 @@ describe('Form state and lifecycle', () => {
 		expect(wrapper.find('span').text()).toBe('');
 		wrapper.unmount();
 	});
+
+	it('should expose form-level isDirty and isValid from the useForm() return', async () => {
+		let formApi: any;
+		const cmp = defineComponent(() => {
+			formApi = useForm({ name: 'fs-return-state' });
+			const { Form, Field } = formApi;
+
+			return () => h(Form, {}, () => [h(Field, { name: 'email' })]);
+		});
+
+		const wrapper = mount(cmp);
+		await nextTick();
+
+		// Pristine, no errors.
+		expect(formApi.isDirty.value).toBe(false);
+		expect(formApi.isValid.value).toBe(true);
+
+		await wrapper.find('input').setValue('hello');
+		await nextTick();
+
+		expect(formApi.isDirty.value).toBe(true);
+		expect(formApi.isValid.value).toBe(true);
+		wrapper.unmount();
+	});
+
+	it('should report form-level isTouched after a field is blurred', async () => {
+		let formApi: any;
+		const cmp = defineComponent(() => {
+			formApi = useForm({ name: 'fs-touched-form' });
+			const { Form, Field } = formApi;
+
+			return () => h(Form, {}, () => [h(Field, { name: 'email' })]);
+		});
+
+		const wrapper = mount(cmp);
+		await nextTick();
+
+		expect(formApi.isTouched.value).toBe(false);
+
+		await wrapper.find('input').trigger('focus');
+		await wrapper.find('input').trigger('blur');
+		await nextTick();
+
+		expect(formApi.isTouched.value).toBe(true);
+		wrapper.unmount();
+	});
+
+	it('should track isSubmitted and submitCount across submits and reset', async () => {
+		let formApi: any;
+		const cmp = defineComponent(() => {
+			formApi = useForm({ name: 'fs-submitcount' });
+			const { Form, Field } = formApi;
+
+			return () => h(Form, { onSubmit: () => {} }, () => [h(Field, { name: 'email' })]);
+		});
+
+		const wrapper = mount(cmp);
+		await nextTick();
+
+		expect(formApi.isSubmitted.value).toBe(false);
+		expect(formApi.submitCount.value).toBe(0);
+
+		await wrapper.find('form').trigger('submit');
+		await nextTick();
+		expect(formApi.isSubmitted.value).toBe(true);
+		expect(formApi.submitCount.value).toBe(1);
+
+		await wrapper.find('form').trigger('submit');
+		await nextTick();
+		expect(formApi.submitCount.value).toBe(2);
+
+		formApi.reset();
+		await nextTick();
+		expect(formApi.isSubmitted.value).toBe(false);
+		expect(formApi.submitCount.value).toBe(0);
+		wrapper.unmount();
+	});
+
+	it('should return a per-field snapshot via getFieldState', async () => {
+		let formApi: any;
+		const cmp = defineComponent(() => {
+			formApi = useForm({ name: 'fs-getfieldstate', initialValues: { email: 'a@b.co' } });
+			const { Form, Field } = formApi;
+
+			return () => h(Form, {}, () => [h(Field, { name: 'email' })]);
+		});
+
+		const wrapper = mount(cmp);
+		await nextTick();
+		await nextTick();
+
+		let state = formApi.getFieldState('email');
+		expect(state.value).toBe('a@b.co');
+		expect(state.isDirty).toBe(false);
+		expect(state.isTouched).toBe(false);
+		expect(state.isValid).toBe(true);
+		expect(state.error).toBeUndefined();
+
+		await wrapper.find('input').setValue('changed@b.co');
+		await nextTick();
+
+		state = formApi.getFieldState('email');
+		expect(state.value).toBe('changed@b.co');
+		expect(state.isDirty).toBe(true);
+
+		formApi.setError('email', 'Bad email');
+		await nextTick();
+
+		state = formApi.getFieldState('email');
+		expect(state.isValid).toBe(false);
+		expect(state.error).toBe('Bad email');
+		wrapper.unmount();
+	});
 });

--- a/src/components/Form.ts
+++ b/src/components/Form.ts
@@ -1,6 +1,6 @@
 import { forms } from '@/utils/store';
-import { FormOptions, GetKeys, Prettify, RecursivePartial } from '@/utils/types';
-import { createFormDataFromObject, EventEmitter, fetcher, flattenObject, getValueByPath, mergeDeep, objectToString, stringToObject, isFormDirty, hasErrors, getErrorMessage } from '@/utils/utils';
+import { FieldState, FormOptions, GetKeys, Prettify, RecursivePartial } from '@/utils/types';
+import { createFormDataFromObject, EventEmitter, fetcher, flattenObject, getValueByPath, mergeDeep, objectToString, stringToObject, isFieldDirty, isFormDirty, isFormTouched, hasErrors, getErrorMessage } from '@/utils/utils';
 import { validateSchema } from '@/utils/validator';
 import { computed, defineComponent, h, nextTick, onMounted, PropType, provide, ref, SlotsType, watch } from 'vue';
 
@@ -21,6 +21,7 @@ export const FormComponent = <T extends Record<string, any> = Record<string, any
 	const isSubmitting = ref<boolean>(false);
 	const isFormReady = ref<boolean>(false);
 	const isSubmitted = ref<boolean>(false);
+	const submitCount = ref<number>(0);
 	let originalForm = Object.create({});
 
 	/*---------------------------------------------
@@ -28,6 +29,7 @@ export const FormComponent = <T extends Record<string, any> = Record<string, any
 	---------------------------------------------*/
 	const reset = (force: boolean = false) => {
 		isSubmitted.value = false;
+		submitCount.value = 0;
 		if (force) {
 			forms[uid].initialValues = Object.create({});
 			forms[uid].values = Object.create({});
@@ -82,6 +84,18 @@ export const FormComponent = <T extends Record<string, any> = Record<string, any
 			getValueByPath(forms[uid].values, name as unknown as string).error = error;
 		}
 	};
+
+	const getFieldState = (name: GetKeys<T>): FieldState => {
+		const field = getValueByPath(forms[uid].values, name as unknown as string);
+
+		return {
+			value: field?.value,
+			error: field?.error,
+			isDirty: isFieldDirty(field),
+			isTouched: !!field?.isTouched,
+			isValid: !field?.error,
+		};
+	};
 	/*---------------------------------------------
 	/  COMPUTED
 	---------------------------------------------*/
@@ -90,6 +104,7 @@ export const FormComponent = <T extends Record<string, any> = Record<string, any
 		set: (newValue: T) => newValue,
 	});
 	const isDirty = computed(() => isFormDirty(forms[uid]?.values));
+	const isTouched = computed(() => isFormTouched(forms[uid]?.values));
 	// Validity is independent of dirtiness: a pristine form with no errors is valid.
 	const isValid = computed(() => !hasErrors(flattenObject(forms[uid]?.values, 'error')));
 	/*---------------------------------------------
@@ -121,6 +136,7 @@ export const FormComponent = <T extends Record<string, any> = Record<string, any
 		const submit = async ($event: any) => {
 			$event.preventDefault();
 			isSubmitted.value = true;
+			submitCount.value++;
 			let _val = values.value;
 
 			if (opt?.schema) {
@@ -203,7 +219,16 @@ export const FormComponent = <T extends Record<string, any> = Record<string, any
 		return () => {
 			return h('form',
 				{ ...props, ...attrs, ...emit, key: forms[uid].key, onSubmit: submit },
-				slots.default?.({ values: values.value, getError, isDirty: isDirty.value, isValid: isValid.value }),
+				slots.default?.({
+					values: values.value,
+					getError,
+					getFieldState,
+					isDirty: isDirty.value,
+					isValid: isValid.value,
+					isTouched: isTouched.value,
+					isSubmitted: isSubmitted.value,
+					submitCount: submitCount.value,
+				}),
 			);
 		};
 	}, {
@@ -222,14 +247,29 @@ export const FormComponent = <T extends Record<string, any> = Record<string, any
 		},
 		emits: ['submit', 'value-change'],
 		slots: Object as SlotsType<{
-			default: { values: T, getError: (name: GetKeys<T>) => string, isDirty: boolean, isValid: boolean }
+			default: {
+				values: T,
+				getError: (name: GetKeys<T>) => string,
+				getFieldState: (name: GetKeys<T>) => FieldState,
+				isDirty: boolean,
+				isValid: boolean,
+				isTouched: boolean,
+				isSubmitted: boolean,
+				submitCount: number,
+			}
 		}>,
 	});
 
 	return {
 		cmp,
 		values,
-		isSubmitting: isSubmitting,
+		isSubmitting,
+		isSubmitted,
+		isDirty,
+		isValid,
+		isTouched,
+		submitCount,
+		getFieldState,
 		reset,
 		setInitialValues,
 		setValue,

--- a/src/composable/useForm.ts
+++ b/src/composable/useForm.ts
@@ -13,9 +13,15 @@ export type UseFormReturn<T extends Record<string, any>> = {
 	setValue: ReturnType<typeof FormComponent<T>>['setValue'];
 	setValues: ReturnType<typeof FormComponent<T>>['setValues'];
 	setError: ReturnType<typeof FormComponent<T>>['setError'];
+	getFieldState: ReturnType<typeof FormComponent<T>>['getFieldState'];
 	handleSubmit: ReturnType<typeof FormComponent<T>>['handleSubmit'];
 	values: ReturnType<typeof FormComponent<T>>['values'];
 	isSubmitting: ReturnType<typeof FormComponent<T>>['isSubmitting'];
+	isSubmitted: ReturnType<typeof FormComponent<T>>['isSubmitted'];
+	isDirty: ReturnType<typeof FormComponent<T>>['isDirty'];
+	isValid: ReturnType<typeof FormComponent<T>>['isValid'];
+	isTouched: ReturnType<typeof FormComponent<T>>['isTouched'];
+	submitCount: ReturnType<typeof FormComponent<T>>['submitCount'];
 };
 
 export const useForm = <T extends Record<string, any>>(opt?: FormOptions<T>): UseFormReturn<T> => {
@@ -34,8 +40,14 @@ export const useForm = <T extends Record<string, any>>(opt?: FormOptions<T>): Us
 		setValue: FormBase.setValue,
 		setValues: FormBase.setValues,
 		setError: FormBase.setError,
+		getFieldState: FormBase.getFieldState,
 		handleSubmit: FormBase.handleSubmit,
 		values: FormBase.values,
 		isSubmitting: FormBase.isSubmitting,
+		isSubmitted: FormBase.isSubmitted,
+		isDirty: FormBase.isDirty,
+		isValid: FormBase.isValid,
+		isTouched: FormBase.isTouched,
+		submitCount: FormBase.submitCount,
 	};
 };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -130,6 +130,14 @@ export type FieldDefaults = {
 	isTouched: boolean,
 }
 
+export type FieldState = {
+	value: any,
+	error: any,
+	isDirty: boolean,
+	isTouched: boolean,
+	isValid: boolean,
+}
+
 export type RecursivePartial<T> = {
 	[P in keyof T]?: T[P] extends Record<string, any> ? RecursivePartial<T[P]> : T[P];
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -296,6 +296,40 @@ export const isFormDirty = (values: Record<string, any>): boolean => {
 	return false;
 };
 
+/**
+ * The form is touched when any field in it has been touched. Like isFormDirty,
+ * but the touched flag lives on the leaf inputs, so this also descends into a
+ * field's nested/array `value` to reach the touched flags of array items.
+ */
+export const isFormTouched = (values: Record<string, any>): boolean => {
+	if (!values || typeof values !== 'object') {
+		return false;
+	}
+
+	for (const key in values) {
+		const node = values[key];
+		if (!node || typeof node !== 'object') {
+			continue;
+		}
+
+		if ('value' in node) {
+			if (node.ignore) {
+				continue;
+			}
+			if (node.isTouched) {
+				return true;
+			}
+			if (node.value && typeof node.value === 'object' && isFormTouched(node.value)) {
+				return true;
+			}
+		} else if (isFormTouched(node)) {
+			return true;
+		}
+	}
+
+	return false;
+};
+
 export function hasErrors(errors: any): boolean {
 	if (typeof errors === 'string' && errors) {
 		return true;


### PR DESCRIPTION
Implementation notes

  - Added `isFormTouched` — mirrors `isFormDirty`'s store walk, but additionally descends into a field's nested/array `value` to reach the `isTouched` flags that live on
  array-item leaves.
  - Added a `FieldState` type. `getFieldState` derives `isDirty/isValid` the same way the field/form do (`isFieldDirty / !error`), preserving the single-source-of-truth
  - `submitCount` increments on each submit attempt; `reset()` clears both `submitCount` and `isSubmitted`.
  - Extended the Form default-slot type with the new props.