### PR TITLE
fix: per-form event bus, store cleanup, stable form ids

### DIFF
--- a/src/__tests__/basic/lifecycle.spec.ts
+++ b/src/__tests__/basic/lifecycle.spec.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { useForm } from '@/main';
+import { forms } from '@/utils/store';
+import { StandardSchemaV1 } from '@/utils/types';
+import { mount } from '@vue/test-utils';
+import { defineComponent, h, nextTick } from 'vue';
+
+const minLength = (field: string, min: number, message: string): StandardSchemaV1<any, any> => ({
+	'~standard': {
+		version: 1,
+		vendor: 'test',
+		validate: (value: any) => {
+			const val = value as Record<string, any>;
+			if (!val[field] || String(val[field]).length < min) {
+				return { issues: [{ message, path: [{ key: field }] }] };
+			}
+
+			return { value: val };
+		},
+	},
+});
+
+describe('Form lifecycle & isolation', () => {
+	afterEach(() => {
+		for (const key of Object.keys(forms)) {
+			if (key.startsWith('lc-')) {
+				delete forms[key];
+			}
+		}
+	});
+
+	it('removes the form store entry when the owner unmounts', async () => {
+		const cmp = defineComponent(() => {
+			const { Form, Field } = useForm({ name: 'lc-cleanup' });
+
+			return () => h(Form, {}, () => [h(Field, { name: 'email' })]);
+		});
+
+		const wrapper = mount(cmp);
+		await nextTick();
+		expect(forms['lc-cleanup']).toBeDefined();
+
+		wrapper.unmount();
+		await nextTick();
+		expect(forms['lc-cleanup']).toBeUndefined();
+	});
+
+	it('keeps the form store entry on unmount when preserve is set', async () => {
+		const cmp = defineComponent(() => {
+			const { Form, Field } = useForm({ name: 'lc-preserve', preserve: true });
+
+			return () => h(Form, {}, () => [h(Field, { name: 'email' })]);
+		});
+
+		const wrapper = mount(cmp);
+		await nextTick();
+		expect(forms['lc-preserve']).toBeDefined();
+
+		wrapper.unmount();
+		await nextTick();
+		expect(forms['lc-preserve']).toBeDefined();
+	});
+
+	it('does not leak onChange validation across separate forms', async () => {
+		let aState: any;
+		let bState: any;
+
+		const cmp = defineComponent(() => {
+			const a = useForm({ name: 'lc-a', mode: 'onChange', schema: minLength('email', 3, 'Too short') });
+			const b = useForm({ name: 'lc-b', mode: 'onChange', schema: minLength('email', 3, 'Too short') });
+			aState = a.getFieldState;
+			bState = b.getFieldState;
+
+			return () => h('div', [
+				h(a.Form, {}, () => [h(a.Field, { name: 'email' })]),
+				h(b.Form, {}, () => [h(b.Field, { name: 'email' })]),
+			]);
+		});
+
+		const wrapper = mount(cmp);
+		await nextTick();
+		await nextTick();
+
+		// Type an invalid value into form A only.
+		const inputs = wrapper.findAll('input');
+		await inputs[0].setValue('ab');
+		await nextTick();
+		await nextTick();
+
+		// Form A is invalid; form B must be untouched (no cross-form bleed).
+		expect(aState('email').error).toBe('Too short');
+		expect(bState('email').error).toBeUndefined();
+		wrapper.unmount();
+	});
+});

--- a/src/__tests__/basic/onchange.spec.ts
+++ b/src/__tests__/basic/onchange.spec.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { useForm } from '@/main';
 import { forms } from '@/utils/store';
 import { StandardSchemaV1 } from '@/utils/types';
-import { EventEmitter } from '@/utils/utils';
 import { mount } from '@vue/test-utils';
 import { defineComponent, h, nextTick } from 'vue';
 
@@ -39,7 +38,6 @@ const createFieldRule = (min: number, message: string): StandardSchemaV1 => ({
 
 describe('onChange validation mode', () => {
 	afterEach(() => {
-		(EventEmitter as any).eventListeners = {};
 		for (const key of Object.keys(forms)) {
 			if (key.startsWith('oc-')) {
 				delete forms[key];

--- a/src/components/Form.ts
+++ b/src/components/Form.ts
@@ -2,7 +2,7 @@ import { forms } from '@/utils/store';
 import { FieldState, FormOptions, GetKeys, Prettify, RecursivePartial } from '@/utils/types';
 import { createFormDataFromObject, EventEmitter, fetcher, flattenObject, getValueByPath, mergeDeep, objectToString, stringToObject, isFieldDirty, isFormDirty, isFormTouched, hasErrors, getErrorMessage } from '@/utils/utils';
 import { validateSchema } from '@/utils/validator';
-import { computed, defineComponent, h, nextTick, onMounted, PropType, provide, ref, SlotsType, watch } from 'vue';
+import { computed, defineComponent, getCurrentInstance, h, nextTick, onBeforeUnmount, onMounted, onUnmounted, PropType, provide, ref, SlotsType, watch } from 'vue';
 
 type FormType<T extends Record<string, any>> = {
 	enctype?: 'application/x-www-form-urlencoded' | 'multipart/form-data';
@@ -13,15 +13,22 @@ type FormType<T extends Record<string, any>> = {
 	onSubmit?: (value?: any, $event?: SubmitEvent) => void | Promise<any>;
 }
 
+// Monotonic counter for auto-generated form ids — collision-free and
+// deterministic, unlike the previous Math.random()/Date.now() scheme.
+let formIdCounter = 0;
+
 export const FormComponent = <T extends Record<string, any> = Record<string, any>>(opt?: FormOptions<T>) => {
 	/*---------------------------------------------
 	/  VARIABLES
 	---------------------------------------------*/
-	const uid: number | string = opt?.name || Math.floor(Math.random() * Date.now());
+	const uid: number | string = opt?.name || `form-${++formIdCounter}`;
 	const isSubmitting = ref<boolean>(false);
 	const isFormReady = ref<boolean>(false);
 	const isSubmitted = ref<boolean>(false);
 	const submitCount = ref<number>(0);
+	// One event bus per form instance — keeps validate/value-change events from
+	// bleeding into other mounted forms (the old global static EventEmitter did).
+	const emitter = new EventEmitter();
 	let originalForm = Object.create({});
 
 	/*---------------------------------------------
@@ -120,12 +127,22 @@ export const FormComponent = <T extends Record<string, any> = Record<string, any
 		values.value = flattenObject(forms[uid].values) as T;
 	}
 
+	// Free the store entry when the owning component unmounts so forms don't
+	// accumulate for the life of the app. Skipped when `preserve` is set, and
+	// tied to the owner (not the <Form> element) so it survives v-if toggles.
+	if (getCurrentInstance() && !opt?.preserve) {
+		onUnmounted(() => {
+			delete forms[uid];
+		});
+	}
+
 	const cmp = defineComponent((props: Prettify<FormType<T>>, { slots, emit, attrs }) => {
 		provide('formData', {
 			uid,
 			preserveForm: opt?.preserve,
 			mode: opt?.mode,
 			isSubmitted,
+			emitter,
 		});
 		/*---------------------------------------------
 		/  METHODS
@@ -178,10 +195,10 @@ export const FormComponent = <T extends Record<string, any> = Record<string, any
 		watch(values, (curr, prev) => {
 			values.value = curr;
 			if (isFormReady.value && JSON.stringify(curr) !== JSON.stringify(prev) && props.onValueChange) {
-				EventEmitter.emit('value-change', uid);
+				emitter.emit('value-change', uid);
 			}
 			if (opt?.mode === 'onChange' && isDirty.value) {
-				EventEmitter.emit('validate');
+				emitter.emit('validate');
 			}
 		}, { deep: true });
 		/*---------------------------------------------
@@ -193,27 +210,43 @@ export const FormComponent = <T extends Record<string, any> = Record<string, any
 		/*---------------------------------------------
 		/  HOOKS
 		---------------------------------------------*/
+		let onValueChangeHandler: ((id: string) => void) | undefined;
+		let onValidateHandler: (() => Promise<boolean | undefined>) | undefined;
+
 		onMounted(async () => {
 			initialValueToValue();
 			originalForm = JSON.stringify(forms[uid].values);
 
 			if (props?.onValueChange && forms[uid]) {
-				EventEmitter.on('value-change', (id: string) => {
+				onValueChangeHandler = (id: string) => {
 					if (id === uid) {
 						emit('value-change', values.value);
 					}
-				});
+				};
+				emitter.on('value-change', onValueChangeHandler);
 			}
 
 			if (opt?.mode === 'onChange') {
-				EventEmitter.on('validate', async () => {
+				onValidateHandler = async () => {
 					if (opt?.schema) {
 						return await validateSchema(opt.schema, flattenObject(forms[uid].values), setError);
 					}
-				});
+				};
+				emitter.on('validate', onValidateHandler);
 			}
 			await nextTick();
 			isFormReady.value = true;
+		});
+
+		// Remove this <Form>'s listeners on unmount so they don't fire after the
+		// component is gone or pile up across v-if remounts.
+		onBeforeUnmount(() => {
+			if (onValueChangeHandler) {
+				emitter.off('value-change', onValueChangeHandler);
+			}
+			if (onValidateHandler) {
+				emitter.off('validate', onValidateHandler);
+			}
 		});
 
 		return () => {

--- a/src/composable/useInput.ts
+++ b/src/composable/useInput.ts
@@ -1,6 +1,6 @@
 import { computed, getCurrentInstance, inject, nextTick, onBeforeUnmount, onMounted, warn } from 'vue';
 import { forms } from '@/utils/store';
-import { cloneValue, createFormInput, deleteByPath, EventEmitter, getValueByPath, isFieldDirty, mergeDeep, objectToModelValue } from '@/utils/utils';
+import { cloneValue, createFormInput, deleteByPath, getValueByPath, isFieldDirty, mergeDeep, objectToModelValue } from '@/utils/utils';
 import { FieldArrayType, FieldDefaults, FieldType, InputProps, UseInputOption } from '@/utils/types';
 import { useFieldValidation } from './useFieldValidation';
 
@@ -38,7 +38,7 @@ const getValueByInputType = (target: HTMLInputElement, trueValue: any, falseValu
 export const useInput = <T extends Record<string, any> = InputProps>(
 	props: FieldType<T> | FieldArrayType<T> & { trueValue: any, falseValue: any } | InputProps<any>, opt: UseInputOption = { isArray: false, isComponent: false }) => {
 	/* INJECTIONS & CONTEXT */
-	const { uid, preserveForm, mode, isSubmitted } = inject('formData', Object.create({}));
+	const { uid, preserveForm, mode, isSubmitted, emitter } = inject('formData', Object.create({}));
 	const vm = getCurrentInstance();
 	const name = props.name as string;
 
@@ -126,7 +126,7 @@ export const useInput = <T extends Record<string, any> = InputProps>(
 		(fieldItem.value && !fieldItem.value?.isTouched) && (fieldItem.value.isTouched = true);
 		resetError();
 		if (mode === 'onChange') {
-			EventEmitter.emit('validate');
+			emitter?.emit('validate');
 			validateField();
 		}
 	};
@@ -204,7 +204,7 @@ export const useInput = <T extends Record<string, any> = InputProps>(
 		'onUpdate:modelValue': (val: any) => {
 			value.value = val;
 			if (mode === 'onChange') {
-				EventEmitter.emit('validate');
+				emitter?.emit('validate');
 				validateField();
 			}
 		},

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -480,10 +480,15 @@ export const fetcher = async (promise?: void | Promise<any>) => {
 /* Custom event handler */
 type EventHandler = (data?: any) => void;
 
+/**
+ * A small event bus. One instance is created per form (provided through the
+ * form context) so events never cross form boundaries and listeners are
+ * garbage-collected with the form rather than accumulating on a global.
+ */
 export class EventEmitter {
-	private static eventListeners: Record<string, EventHandler[]> = {};
+	private eventListeners: Record<string, EventHandler[]> = {};
 
-	static on(eventName: string, handler: EventHandler): void {
+	on(eventName: string, handler: EventHandler): void {
 		if (!this.eventListeners[eventName]) {
 			this.eventListeners[eventName] = [];
 		}
@@ -491,7 +496,7 @@ export class EventEmitter {
 		this.eventListeners[eventName].push(handler);
 	}
 
-	static off(eventName: string, handler: EventHandler): void {
+	off(eventName: string, handler: EventHandler): void {
 		const listeners = this.eventListeners[eventName];
 
 		if (listeners) {
@@ -499,7 +504,7 @@ export class EventEmitter {
 		}
 	}
 
-	static emit(eventName: string, data?: any): void {
+	emit(eventName: string, data?: any): void {
 		const listeners = this.eventListeners[eventName];
 
 		if (listeners) {


### PR DESCRIPTION
Field state polish, batch 4 — fix the lifecycle/memory issues around the form store and the event bus.

EventEmitter was a global static singleton:
- 'validate' events bled across forms — any onChange field change re-ran every other mounted form's schema validation (could set spurious errors on unrelated forms).
- Listeners registered in the Form's onMounted were never removed, so they accumulated across mount/unmount cycles.

Now each form owns an EventEmitter instance, provided through the form context (formData inject) and used by its fields. Events can't cross form boundaries, and the Form removes its own listeners on unmount.

Also:
- The form store entry (forms[uid]) was never deleted; it now frees on the owner's unmount (skipped when `preserve` is set, and tied to the owner rather than the <Form> element so it survives v-if toggles).
- Auto-generated form ids now use a monotonic counter instead of Math.random()/Date.now(), which could collide.