### PR TITLE
Feature/validation flow and types

### DIFF
--- a/src/__tests__/basic/validation-flow.spec.ts
+++ b/src/__tests__/basic/validation-flow.spec.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { useForm } from '@/main';
+import { forms } from '@/utils/store';
+import { StandardSchemaV1 } from '@/utils/types';
+import { mount } from '@vue/test-utils';
+import { defineComponent, h, nextTick } from 'vue';
+
+const minLength = (field: string, min: number, message: string): StandardSchemaV1<any, any> => ({
+	'~standard': {
+		version: 1,
+		vendor: 'test',
+		validate: (value: any) => {
+			const val = value as Record<string, any>;
+			if (!val[field] || String(val[field]).length < min) {
+				return { issues: [{ message, path: [{ key: field }] }] };
+			}
+
+			return { value: val };
+		},
+	},
+});
+
+describe('Validation flow', () => {
+	afterEach(() => {
+		for (const key of Object.keys(forms)) {
+			if (key.startsWith('vf-')) {
+				delete forms[key];
+			}
+		}
+	});
+
+	it('runs the schema exactly once per change in onChange mode', async () => {
+		let count = 0;
+		const countingSchema: StandardSchemaV1<any, any> = {
+			'~standard': {
+				version: 1,
+				vendor: 'test',
+				validate: (value: any) => {
+					count++;
+
+					return { value };
+				},
+			},
+		};
+
+		const cmp = defineComponent(() => {
+			const { Form, Field } = useForm({ name: 'vf-dedup', mode: 'onChange', schema: countingSchema });
+
+			return () => h(Form, {}, () => [h(Field, { name: 'email' })]);
+		});
+
+		const wrapper = mount(cmp);
+		await nextTick();
+		await nextTick();
+
+		count = 0;
+		await wrapper.find('input').setValue('x');
+		await nextTick();
+		await nextTick();
+
+		// Previously the field emit + the values watcher each triggered a pass (2).
+		expect(count).toBe(1);
+		wrapper.unmount();
+	});
+
+	it('validate() surfaces schema errors and returns validity', async () => {
+		let api: any;
+		const cmp = defineComponent(() => {
+			api = useForm({ name: 'vf-validate', mode: 'onChange', schema: minLength('email', 3, 'Too short') });
+			const { Form, Field, Error } = api;
+
+			return () => h(Form, {}, () => [h(Field, { name: 'email' }), h(Error, { errorFor: 'email' })]);
+		});
+
+		const wrapper = mount(cmp);
+		await nextTick();
+
+		// Pristine in onChange mode: no error shown yet.
+		expect(wrapper.find('span').text()).toBe('');
+
+		const invalid = await api.validate();
+		await nextTick();
+		expect(invalid).toBe(false);
+		// validate() marks the form submitted, so the gated message becomes visible.
+		expect(wrapper.find('span').text()).toBe('Too short');
+
+		await wrapper.find('input').setValue('abc');
+		await nextTick();
+		const valid = await api.validate();
+		await nextTick();
+		expect(valid).toBe(true);
+		expect(wrapper.find('span').text()).toBe('');
+		wrapper.unmount();
+	});
+
+	it('validate() resolves true when there is no schema', async () => {
+		let api: any;
+		const cmp = defineComponent(() => {
+			api = useForm({ name: 'vf-noschema' });
+			const { Form, Field } = api;
+
+			return () => h(Form, {}, () => [h(Field, { name: 'email' })]);
+		});
+
+		const wrapper = mount(cmp);
+		await nextTick();
+
+		expect(await api.validate()).toBe(true);
+		wrapper.unmount();
+	});
+
+	it('clearErrors() clears a single field or every field', async () => {
+		let api: any;
+		const cmp = defineComponent(() => {
+			api = useForm({ name: 'vf-clear' });
+			const { Form, Field } = api;
+
+			return () => h(Form, {}, () => [h(Field, { name: 'email' }), h(Field, { name: 'name' })]);
+		});
+
+		const wrapper = mount(cmp);
+		await nextTick();
+
+		api.setError('email', 'E1');
+		api.setError('name', 'N1');
+		await nextTick();
+		expect(api.getFieldState('email').error).toBe('E1');
+		expect(api.getFieldState('name').error).toBe('N1');
+
+		// Clear a single field by name.
+		api.clearErrors('email');
+		await nextTick();
+		expect(api.getFieldState('email').error).toBeUndefined();
+		expect(api.getFieldState('name').error).toBe('N1');
+
+		// Clear all remaining errors.
+		api.setError('email', 'E2');
+		api.clearErrors();
+		await nextTick();
+		expect(api.getFieldState('email').error).toBeUndefined();
+		expect(api.getFieldState('name').error).toBeUndefined();
+		wrapper.unmount();
+	});
+});

--- a/src/components/Form.ts
+++ b/src/components/Form.ts
@@ -1,6 +1,6 @@
 import { forms } from '@/utils/store';
 import { FieldState, FormOptions, GetKeys, Prettify, RecursivePartial } from '@/utils/types';
-import { createFormDataFromObject, EventEmitter, fetcher, flattenObject, getValueByPath, mergeDeep, objectToString, stringToObject, isFieldDirty, isFormDirty, isFormTouched, hasErrors, getErrorMessage } from '@/utils/utils';
+import { createFormDataFromObject, clearStoreErrors, EventEmitter, fetcher, flattenObject, getValueByPath, mergeDeep, objectToString, stringToObject, isFieldDirty, isFormDirty, isFormTouched, hasErrors, getErrorMessage } from '@/utils/utils';
 import { validateSchema } from '@/utils/validator';
 import { computed, defineComponent, getCurrentInstance, h, nextTick, onBeforeUnmount, onMounted, onUnmounted, PropType, provide, ref, SlotsType, watch } from 'vue';
 
@@ -102,6 +102,32 @@ export const FormComponent = <T extends Record<string, any> = Record<string, any
 			isTouched: !!field?.isTouched,
 			isValid: !field?.error,
 		};
+	};
+
+	// Imperatively run the form's schema against the current values, surfacing
+	// any errors (marks the form submitted so gated messages become visible).
+	// Returns whether the form is valid; forms without a schema are always valid.
+	const validate = async (): Promise<boolean> => {
+		isSubmitted.value = true;
+		if (opt?.schema) {
+			return await validateSchema(opt.schema, flattenObject(forms[uid].values), setError);
+		}
+
+		return true;
+	};
+
+	// Clear a single field's error (by name) or every field's error.
+	const clearErrors = (name?: GetKeys<T>) => {
+		if (name) {
+			const field = getValueByPath(forms[uid].values, name as unknown as string);
+			if (field) {
+				field.error = undefined;
+			}
+
+			return;
+		}
+
+		clearStoreErrors(forms[uid].values);
 	};
 	/*---------------------------------------------
 	/  COMPUTED
@@ -308,6 +334,8 @@ export const FormComponent = <T extends Record<string, any> = Record<string, any
 		setValue,
 		setValues,
 		setError,
+		validate,
+		clearErrors,
 		handleSubmit,
 	};
 };

--- a/src/components/Form.ts
+++ b/src/components/Form.ts
@@ -132,10 +132,7 @@ export const FormComponent = <T extends Record<string, any> = Record<string, any
 	/*---------------------------------------------
 	/  COMPUTED
 	---------------------------------------------*/
-	const values = computed({
-		get: () => flattenObject(forms[uid]?.values) as T,
-		set: (newValue: T) => newValue,
-	});
+	const values = computed(() => flattenObject(forms[uid]?.values) as T);
 	const isDirty = computed(() => isFormDirty(forms[uid]?.values));
 	const isTouched = computed(() => isFormTouched(forms[uid]?.values));
 	// Validity is independent of dirtiness: a pristine form with no errors is valid.
@@ -149,8 +146,6 @@ export const FormComponent = <T extends Record<string, any> = Record<string, any
 			initialValues: opt?.initialValues || Object.create({}),
 			key: 0,
 		};
-	} else {
-		values.value = flattenObject(forms[uid].values) as T;
 	}
 
 	// Free the store entry when the owning component unmounts so forms don't
@@ -219,7 +214,6 @@ export const FormComponent = <T extends Record<string, any> = Record<string, any
 		/  WATCHERS
 		---------------------------------------------*/
 		watch(values, (curr, prev) => {
-			values.value = curr;
 			if (isFormReady.value && JSON.stringify(curr) !== JSON.stringify(prev) && props.onValueChange) {
 				emitter.emit('value-change', uid);
 			}

--- a/src/composable/useForm.ts
+++ b/src/composable/useForm.ts
@@ -14,6 +14,8 @@ export type UseFormReturn<T extends Record<string, any>> = {
 	setValues: ReturnType<typeof FormComponent<T>>['setValues'];
 	setError: ReturnType<typeof FormComponent<T>>['setError'];
 	getFieldState: ReturnType<typeof FormComponent<T>>['getFieldState'];
+	validate: ReturnType<typeof FormComponent<T>>['validate'];
+	clearErrors: ReturnType<typeof FormComponent<T>>['clearErrors'];
 	handleSubmit: ReturnType<typeof FormComponent<T>>['handleSubmit'];
 	values: ReturnType<typeof FormComponent<T>>['values'];
 	isSubmitting: ReturnType<typeof FormComponent<T>>['isSubmitting'];
@@ -41,6 +43,8 @@ export const useForm = <T extends Record<string, any>>(opt?: FormOptions<T>): Us
 		setValues: FormBase.setValues,
 		setError: FormBase.setError,
 		getFieldState: FormBase.getFieldState,
+		validate: FormBase.validate,
+		clearErrors: FormBase.clearErrors,
 		handleSubmit: FormBase.handleSubmit,
 		values: FormBase.values,
 		isSubmitting: FormBase.isSubmitting,

--- a/src/composable/useInput.ts
+++ b/src/composable/useInput.ts
@@ -38,7 +38,7 @@ const getValueByInputType = (target: HTMLInputElement, trueValue: any, falseValu
 export const useInput = <T extends Record<string, any> = InputProps>(
 	props: FieldType<T> | FieldArrayType<T> & { trueValue: any, falseValue: any } | InputProps<any>, opt: UseInputOption = { isArray: false, isComponent: false }) => {
 	/* INJECTIONS & CONTEXT */
-	const { uid, preserveForm, mode, isSubmitted, emitter } = inject('formData', Object.create({}));
+	const { uid, preserveForm, mode, isSubmitted } = inject('formData', Object.create({}));
 	const vm = getCurrentInstance();
 	const name = props.name as string;
 
@@ -126,7 +126,8 @@ export const useInput = <T extends Record<string, any> = InputProps>(
 		(fieldItem.value && !fieldItem.value?.isTouched) && (fieldItem.value.isTouched = true);
 		resetError();
 		if (mode === 'onChange') {
-			emitter?.emit('validate');
+			// Form-level schema validation is driven by the Form's values watcher;
+			// here we only run this field's own rule to avoid a duplicate pass.
 			validateField();
 		}
 	};
@@ -204,7 +205,6 @@ export const useInput = <T extends Record<string, any> = InputProps>(
 		'onUpdate:modelValue': (val: any) => {
 			value.value = val;
 			if (mode === 'onChange') {
-				emitter?.emit('validate');
 				validateField();
 			}
 		},

--- a/src/utils/store.ts
+++ b/src/utils/store.ts
@@ -1,8 +1,23 @@
 import { reactive } from 'vue';
 
-type FormStore = {
-	values: Record<string, any>;
+/**
+ * A single field entry in the store. The known keys describe a leaf field;
+ * the index signature covers nested path segments and array items (`[0]`, …),
+ * which are themselves FieldStore nodes.
+ */
+export interface FieldStore {
+	value?: any;
+	initialValue?: any;
+	error?: any;
+	ignore?: boolean;
+	isTouched?: boolean;
+	[key: string]: any;
+}
+
+export type FormStore = {
+	values: Record<string, FieldStore>;
 	initialValues: Record<string, any>;
 	key: number;
 }
+
 export const forms = reactive<Record<string, FormStore>>({});

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -297,6 +297,32 @@ export const isFormDirty = (values: Record<string, any>): boolean => {
 };
 
 /**
+ * Clear the `error` on every field in the store (scalar, object-value and
+ * array fields), descending into nested/array values like isFormTouched.
+ */
+export const clearStoreErrors = (values: Record<string, any>): void => {
+	if (!values || typeof values !== 'object') {
+		return;
+	}
+
+	for (const key in values) {
+		const node = values[key];
+		if (!node || typeof node !== 'object') {
+			continue;
+		}
+
+		if ('value' in node) {
+			node.error = undefined;
+			if (node.value && typeof node.value === 'object') {
+				clearStoreErrors(node.value);
+			}
+		} else {
+			clearStoreErrors(node);
+		}
+	}
+};
+
+/**
  * The form is touched when any field in it has been touched. Like isFormDirty,
  * but the touched flag lives on the leaf inputs, so this also descends into a
  * field's nested/array `value` to reach the touched flags of array items.


### PR DESCRIPTION
 - Removed the double validation pass in onChange mode. A field change emitted a validate event
  and the Form's values watcher also emitted one, so the schema ran twice per keystroke. The field
  now only runs its own rule; the form schema is driven solely by the values watcher — one pass 
  per change.
  - Added useForm().validate() — imperatively runs the schema against current values, surfaces any
  errors (marks the form submitted so gated messages become visible), and resolves the validity
  boolean. Forms without a schema resolve true. Useful for wizard steps and conditional flows.
  - Added useForm().clearErrors(name?) — clears a single field's error by name, or every field's
  error when called with no argument (via a new clearStoreErrors store walker).
  - Typed and exported FormStore plus a FieldStore node interface that documents the known
  field-entry shape (value, initialValue, error, ignore, isTouched) while keeping an index
  signature for nested path segments and array items. It was previously a bare, unexported
  Record<string, any>.
  - Removed the no-op setter on the values computed (set: (v) => v returned its argument without
  mutating anything) along with the two dead values.value = ... writes that depended on it. values
  is now a plain read-only computed.